### PR TITLE
Potential fix for code scanning alert no. 2: Second order command injection

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,9 +15,21 @@ import {Inputs} from './inputs'
 
 const MINIMUM_GIT_VERSION = '2.18.0'
 
+/**
+ * Validates the arguments provided for a Git fetch operation.
+ *
+ * This function ensures that none of the arguments contain forbidden flags such as '--upload-pack',
+ * detecting potential command injection attempts. The check is case insensitive and verifies partial matches.
+ *
+ * @param args - An array of strings representing Git fetch arguments.
+ * @returns `true` if the arguments are valid, `false` otherwise.
+ */
 const validateGitFetchArgs = (args: string[]): boolean => {
   const forbiddenArgs = ['--upload-pack'];
-  return !args.some(arg => forbiddenArgs.includes(arg));
+  return !args.some(arg => {
+    const lowerArg = arg.toLowerCase();
+    return forbiddenArgs.some(forbidden => lowerArg.includes(forbidden.toLowerCase()));
+  });
 }
 
 export const isWindows = (): boolean => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,11 @@ import {Inputs} from './inputs'
 
 const MINIMUM_GIT_VERSION = '2.18.0'
 
+const validateGitFetchArgs = (args: string[]): boolean => {
+  const forbiddenArgs = ['--upload-pack'];
+  return !args.some(arg => forbiddenArgs.includes(arg));
+}
+
 export const isWindows = (): boolean => {
   return process.platform === 'win32'
 }
@@ -297,6 +302,9 @@ export const gitFetch = async ({
   args: string[]
   cwd: string
 }): Promise<number> => {
+  if (!validateGitFetchArgs(args)) {
+    throw new Error('Invalid arguments for git fetch');
+  }
   const {exitCode} = await exec.getExecOutput('git', ['fetch', '-q', ...args], {
     cwd,
     ignoreReturnCode: true,


### PR DESCRIPTION
Potential fix for [https://github.com/robaone-redshelf/tj-actions-changed-files/security/code-scanning/2](https://github.com/robaone-redshelf/tj-actions-changed-files/security/code-scanning/2)

To fix the problem, we need to sanitize the user-provided input before passing it to the `gitFetch` function. Specifically, we should ensure that the `args` parameter does not contain any malicious commands such as `--upload-pack`. We can achieve this by validating the `args` parameter to ensure it only contains safe and expected values.

1. Add a validation function to check the `args` parameter for any malicious commands.
2. Use this validation function before calling the `gitFetch` function to ensure the `args` parameter is safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for Git fetch operations so that unsupported parameters are now detected promptly. Users will receive a clear error message when attempting to execute Git fetch with invalid arguments. This update enhances both reliability and security during Git interactions, ensuring smoother and more predictable behavior during command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->